### PR TITLE
fix broken windows build

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -22,6 +22,10 @@ add_library(${PLUGIN_NAME} SHARED
   "av_media_player_plugin.cpp"
 )
 
+if(MSVC)
+  target_compile_options(${PLUGIN_NAME} PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR=1>")
+endif()
+
 # Apply a standard set of build settings that are configured in the
 # application-level CMakeLists.txt. This can be removed for plugins that want
 # full control over build settings.

--- a/windows/av_media_player_plugin.cpp
+++ b/windows/av_media_player_plugin.cpp
@@ -272,7 +272,7 @@ class AvMediaPlayer : public enable_shared_from_this<AvMediaPlayer> {
 	int16_t getDefaultVideoTrack() {
 		auto tracks = mediaPlayer.Source().as<MediaPlaybackItem>().VideoTracks();
 		uint32_t maxRes = 0;
-		uint32_t maxBit = 0
+		uint32_t maxBit = 0;
 		int16_t maxId = -1;
 		uint32_t minRes = UINT32_MAX;
 		uint32_t minBit = UINT16_MAX;


### PR DESCRIPTION
1. Add missing semicolon in `/lib/windows/av_media_player_plugin.cc`

2. Add `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` flag, which allows us to run av_media_player on Windows systems with older VC runtime libraries. ([microsoft/STL changelog](https://github.com/microsoft/STL/wiki/Changelog#vs-2022-1710))