### PR TITLE
Fix windows build issue

### DIFF
--- a/windows/av_media_player_plugin.cpp
+++ b/windows/av_media_player_plugin.cpp
@@ -38,7 +38,7 @@ class AvMediaPlayer : public enable_shared_from_this<AvMediaPlayer> {
 				DQTYPE_THREAD_CURRENT,
 				DQTAT_COM_NONE
 			},
-			(PDISPATCHERQUEUECONTROLLER*)put_abi(dispatcherController)
+			reinterpret_cast<ABI::Windows::System::IDispatcherQueueController**>(winrt::put_abi(dispatcherController))
 		));
 		dispatcherQueue = dispatcherController.DispatcherQueue();
 	}


### PR DESCRIPTION
Fixed this compile issue:

```
Building Windows application...                                 
av_media_player\av_media_player_plugin.cpp(41,5): error C2065: 'PDISPATCHERQUEUECONTROLLER': undeclared identifier [av_media_player\av_media_player_plugin.vcxproj]

av_media_player\windows\av_media_player_plugin.cpp(41,32): error C2059: syntax error: ')' 

[plugins\av_media_player\av_media_player_plugin.vcxproj]
```